### PR TITLE
Camel casing and log reduction

### DIFF
--- a/pricing-poc/log4j2.properties
+++ b/pricing-poc/log4j2.properties
@@ -1,0 +1,24 @@
+# Root logger configuration
+rootLogger.level = info
+rootLogger.appenderRefs = stdout, logfile
+rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.logfile.ref = LOGFILE
+
+appenders = console, file
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = error
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} [%t] %-5p %c %x - %m%n
+
+# File appender configuration
+appender.file.type = File
+appender.file.name = LOGFILE
+appender.file.fileName = /tmp/.logs/spark-debug.log
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = warn
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{ISO8601} [%t] %-5p %c %x - %m%n

--- a/pricing-poc/src/main/resources/reports/samples/sku-vm-full-fidelity.json
+++ b/pricing-poc/src/main/resources/reports/samples/sku-vm-full-fidelity.json
@@ -1,0 +1,219 @@
+{
+    "TimeCreated": "2025-03-12T07:00:33.8496818Z",
+    "SkuRecommendationForServers": [
+        {
+            "ServerName": "ARCBOX-SQL",
+            "TargetPlatform": "AzureSqlVirtualMachine",
+            "Requirements": {
+                "CpuRequirementInCores": 0.00,
+                "DataStorageRequirementInMB": 21.94,
+                "LogStorageRequirementInMB": 2.00,
+                "MemoryRequirementInMB": 3.83,
+                "InstanceIOPSDataLogFileRequirement": 0.05,
+                "DataIOPSRequirement": 0.05,
+                "LogIOPSRequirement": 0.01,
+                "IOLatencyRequirementInMs": 0.05,
+                "IOThroughputRequirementInMBps": 0.00,
+                "DataIOThroughputRequirementInMBps": 0.00,
+                "LogIOThroughputRequirementInMBps": 0.00,
+                "InstanceId": "ARCBOX-SQL",
+                "InstanceVersion": "15.0.2104.1",
+                "InstanceEdition": "Developer Edition (64-bit)",
+                "LogicalCpuCount": 1,
+                "ServerCollation": "SQL_Latin1_General_CP1_CI_AS",
+                "HyperthreadRatio": 1.00,
+                "PhysicalCpuCount": 1.00,
+                "MaxServerMemoryInUse": 2147483647.00,
+                "TempDBSizeInMB": 72.00,
+                "NumOfLogins": 16,
+                "SqlStartTime": "2025-03-11T11:38:05",
+                "AggregatedPhysicalMemoryInUse": 272.48,
+                "AggregatedMemoryUtilizationPercentage": 99.21,
+                "AggregatedSqlInstanceCpuPercent": 0.00,
+                "DataPointsStartTime": "0001-01-01T08:00:00Z",
+                "DataPointsEndTime": "2025-03-12T07:00:24.0562211Z",
+                "AggregationTargetPercentile": 95,
+                "PerfDataCollectionIntervalInSeconds": 30,
+                "SqlServerHostRequirements": {
+                    "HostNICCount": 1
+                },
+                "IsSqlServerFci": false,
+                "IsSqlServerHostingAvailabilityGroup": false,
+                "DatabaseLevelRequirements": [
+                    {
+                        "DatabaseCollation": "SQL_Latin1_General_CP1_CI_AS",
+                        "CpuRequirementInCores": 0.00,
+                        "CpuRequirementInPercentageOfTotalInstance": 0.00,
+                        "MemoryRequirementInMB": 3.83,
+                        "DataIOPSRequirement": 0.05,
+                        "LogIOPSRequirement": 0.01,
+                        "IOLatencyRequirementInMs": 0.05,
+                        "IOThroughputRequirementInMBps": 0.00,
+                        "DataFileIOThroughputRequirementInMBps": 0.00,
+                        "LogFileIOThroughputRequirementInMBps": 0.00,
+                        "LogWriteRateInMBPerSecRequirement": 0.00,
+                        "DataStorageRequirementInMB": 21.94,
+                        "LogStorageRequirementInMB": 2.00,
+                        "DatabaseName": "AdventureWorksLT2019",
+                        "AggregatedCachedSizeInMb": 3.83,
+                        "AggregatedCpuPercent": 0.00,
+                        "ExcludeFromRecommendation": false,
+                        "FileLevelRequirements": [
+                            {
+                                "ParentDatabaseName": "AdventureWorksLT2019",
+                                "FileLogicalName": "AdventureWorksLT2012_Data",
+                                "FileName": "C:\\Program Files\\Microsoft SQL Server\\MSSQL15.MSSQLSERVER\\MSSQL\\DATA\\AdventureWorksLT2012.mdf",
+                                "FileType": "Rows",
+                                "SizeInMB": 21.94,
+                                "ReadLatencyInMs": 0.06,
+                                "WriteLatencyInMs": 0.03,
+                                "AggregatedNumOfReads": 0.82,
+                                "AggregatedNumOfWrites": 0.58,
+                                "AggregatedReadIOInMb": 0.09,
+                                "AggregatedWriteIOInMb": 0.00,
+                                "CollectionInterval": 30.00,
+                                "IOPSRequirement": 0.05,
+                                "IOThroughputRequirementInMBps": 0.00,
+                                "WriteRateRequirementInMBps": 0.00,
+                                "NumberOfDataPointsAnalyzed": 9144.00
+                            }
+                        ],
+                        "NumberOfDataPointsAnalyzed": 1629.00
+                    }
+                ],
+                "NumberOfDataPointsAnalyzed": 4821.00
+            },
+            "SkuRecommendationResults": [
+                {
+                    "SqlInstanceName": "ARCBOX-SQL",
+                    "ServerCollation": "SQL_Latin1_General_CP1_CI_AS",
+                    "TargetSku": {
+                        "VirtualMachineSize": {
+                            "VirtualMachineFamily": "standardDASv4Family",
+                            "SizeName": "D2as_v4",
+                            "ComputeSize": 2,
+                            "AzureSkuName": "Standard_D2as_v4",
+                            "vCPUsAvailable": 2,
+                            "MaxNetworkInterfaces": 0
+                        },
+                        "DataDiskSizes": [
+                            {
+                                "Type": "PremiumSSD",
+                                "Redundancy": "LocallyRedundant",
+                                "Size": "P2",
+                                "Caching": "ReadOnly",
+                                "MaxSizeInGib": 8.00,
+                                "MaxThroughputInMbps": 25.00,
+                                "MaxIOPS": 120.00
+                            }
+                        ],
+                        "LogDiskSizes": [
+                            {
+                                "Type": "PremiumSSD",
+                                "Redundancy": "LocallyRedundant",
+                                "Size": "P2",
+                                "Caching": "None",
+                                "MaxSizeInGib": 8.00,
+                                "MaxThroughputInMbps": 25.00,
+                                "MaxIOPS": 120.00
+                            }
+                        ],
+                        "TempDbDiskSizes": [
+                            {
+                                "Type": "PremiumSSD",
+                                "Redundancy": "LocallyRedundant",
+                                "Size": "P2",
+                                "Caching": "None",
+                                "MaxSizeInGib": 8.00,
+                                "MaxThroughputInMbps": 25.00,
+                                "MaxIOPS": 120.00
+                            }
+                        ],
+                        "PredictedDataSizeInMb": 21.94,
+                        "PredictedLogSizeInMb": 2.00,
+                        "Category": {
+                            "VirtualMachineFamily": "standardDASv4Family",
+                            "AvailableVmSkus": [
+                                "Standard_D16as_v4"
+                            ],
+                            "SqlTargetPlatform": "AzureSqlVirtualMachine"
+                        },
+                        "ComputeSize": 2
+                    },
+                    "MonthlyCost": {
+                        "ComputeCost": 81.98,
+                        "StorageCost": 2.40,
+                        "IopsCost": 0.00,
+                        "TotalCost": 84.38
+                    },
+                    "Ranking": 0,
+                    "RecommendationReasonings": [
+                        {
+                            "ReasoningType": "PositiveReasoning",
+                            "ReasoningEnum": "MeetsVirtualMachineCpuScalingFactorRequirementGreaterThanSource",
+                            "ReasoningString": "Considering the 0.001% utilization of the 1 cores according to the performance data collected, 2 vCores are recommended. The recommended Azure VM size provides more compute than your source requires. However, a smaller SKU was not recommended because of other factors, including memory, storage, and IO.",
+                            "ReasoningCategory": "CpuType",
+                            "Parameters": {
+                                "CoreUtilizationPercentage": "0.001",
+                                "AllocatedCores": "1",
+                                "TargetCoresRecommended": "2"
+                            }
+                        },
+                        {
+                            "ReasoningType": "PositiveReasoning",
+                            "ReasoningEnum": "MeetsVirtualMachineMemoryRequirement",
+                            "ReasoningString": "Given the memory requirement of 0.004 GB, 8 GB memory was recommended.",
+                            "ReasoningCategory": "MemoryType",
+                            "Parameters": {
+                                "BufferPoolSizeInGB": "0.004",
+                                "RAMRecommendedInGB": "8"
+                            }
+                        },
+                        {
+                            "ReasoningType": "PositiveReasoning",
+                            "ReasoningEnum": "MeetsVirtualMachineIOPSRequirement",
+                            "ReasoningString": "Data and log files require 0.05474304306005308 IOPS which can be met by this disk's uncached limit of 3200 IOPS.",
+                            "ReasoningCategory": "IOPSType",
+                            "Parameters": {
+                                "VirtualMachineIOPSRequiredInIOPerSec": "0.05474304306005308",
+                                "VirtualMachineUncachedDiskIOPSAvailableInIOPerSec": "3200"
+                            }
+                        },
+                        {
+                            "ReasoningType": "PositiveReasoning",
+                            "ReasoningEnum": "MeetsVirtualMachineIOThroughputRequirement",
+                            "ReasoningString": "Combined read and write IO throughput requirement is 0.003 MB/second which can be met by this SKU's throughput of 48 MB/second.",
+                            "ReasoningCategory": "ThroughputType",
+                            "Parameters": {
+                                "VirtualMachineIOThroughputRequiredInInMBPerSec": "0.003",
+                                "VirtualMachineIOThroughputUncachedAvailableInIOPerSec": "48"
+                            }
+                        },
+                        {
+                            "ReasoningType": "PositiveReasoning",
+                            "ReasoningEnum": "MeetsVirtualMachineStorageRequirement",
+                            "ReasoningString": "2 PremiumSSD(P2) are recommended.",
+                            "ReasoningCategory": "StorageType",
+                            "Parameters": {
+                                "CommaSeperatedManagedDisks": "2 PremiumSSD(P2)"
+                            }
+                        },
+                        {
+                            "ReasoningType": "PositiveReasoning",
+                            "ReasoningEnum": "MeetsVirtualMachineFamilyRequirement",
+                            "ReasoningString": "standardDASv4Family was the most cost-effective SQL Server on Azure VM size in the consideration set.",
+                            "ReasoningCategory": "ServiceTier",
+                            "Parameters": {
+                                "VirtualMachineSize": "standardDASv4Family"
+                            }
+                        }
+                    ],
+                    "PositiveJustifications": [
+                        "According to the performance data collected, we estimate that your instance has a compute requirement of 0.00 vCores. Based on other factors, including memory, storage, and IO, this is the smallest compute sizing that will satisfy all of your requirements.",
+                        "We recommend placing tempdb on the local ephemeral SSD. This Virtual Machine size supports temporary local storage of up to 16.00 GB, which is large enough to host your 0.07 GB tempdb."
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/pricing-poc/src/main/scala/example/Main.scala
+++ b/pricing-poc/src/main/scala/example/Main.scala
@@ -11,11 +11,13 @@ import org.apache.spark.sql.Column
 
 object Main extends App {
 
-  val reportsDirPath = Paths
-    .get(System.getProperty("user.dir"), "src", "main", "resources", "reports")
-    .toString
+  val reportsDirPath = Paths.get(System.getProperty("user.dir"), "src", "main", "resources", "reports").toString
+  val log4jConfigPath = Paths.get(System.getProperty("user.dir"), "log4j2.properties").toString
+  System.setProperty("log4j.configurationFile", s"file://$log4jConfigPath")
+
   val skuReportsDirPath = Paths.get(reportsDirPath, "sku").toString
   val suitabilityDirPath = Paths.get(reportsDirPath, "suitability").toString
+  val sampleReportsDirPath = Paths.get(reportsDirPath, "samples").toString
 
   val spark = SparkUtils.createSparkSession()
 
@@ -28,9 +30,11 @@ object Main extends App {
     val vmFile = Paths.get(skuReportsDirPath, "sku-vm.json").toString
     val suitabilityFile = Paths.get(suitabilityDirPath, "suit.json").toString
 
+    val vmSchemaFile = Paths.get(sampleReportsDirPath, "sku-vm-full-fidelity.json").toString
+
     val dbDf = JsonReader.readJson(spark, dbFile)
     val miDf = JsonReader.readJson(spark, miFile)
-    val vmDf = JsonReader.readJson(spark, vmFile)
+    val vmDf = JsonReader.readJsonWithSchemaInferred(spark, vmFile, vmSchemaFile)
 
     val suitDf = JsonReader.readJson(spark, suitabilityFile)
 

--- a/pricing-poc/src/main/scala/example/Main.scala
+++ b/pricing-poc/src/main/scala/example/Main.scala
@@ -332,6 +332,66 @@ object Main extends App {
           )
         ).alias("skuRecommendationResults")
       )
+      .withColumn("skuRecommendationResults",
+        expr(
+          """
+          transform(
+            map_values(skuRecommendationResults),
+            x -> struct(
+              x.recommendationStatus as recommendationStatus,
+              x.numberOfServerBlockerIssues as numberOfServerBlockerIssues,
+              struct(
+                x.targetSku.category as category,
+                x.targetSku.storageMaxSizeInMb as storageMaxSizeInMb,
+                x.targetSku.predictedDataSizeInMb as predictedDataSizeInMb,
+                x.targetSku.predictedLogSizeInMb as predictedLogSizeInMb,
+                x.targetSku.maxStorageIops as maxStorageIops,
+                x.targetSku.maxThroughputMBps as maxThroughputMBps,
+                x.targetSku.computeSize as computeSize,
+                transform(
+                  x.targetSku.dataDiskSizes,
+                  y -> struct(
+                    y.Caching as caching,
+                    y.MaxIOPS as maxIOPS,
+                    y.MaxSizeInGib as maxSizeInGib,
+                    y.MaxThroughputInMbps as maxThroughputInMbps,
+                    y.Redundancy as redundancy,
+                    y.Size as size,
+                    y.Type as type
+                  )
+                ) as dataDiskSizes,
+                transform(
+                  x.targetSku.logDiskSizes,
+                  y -> struct(
+                    y.Caching as caching,
+                    y.MaxIOPS as maxIOPS,
+                    y.MaxSizeInGib as maxSizeInGib,
+                    y.MaxThroughputInMbps as maxThroughputInMbps,
+                    y.Redundancy as redundancy,
+                    y.Size as size,
+                    y.Type as type
+                  )
+                ) as logDiskSizes,
+                transform(
+                  x.targetSku.tempDbDiskSizes,
+                  y -> struct(
+                    y.Caching as caching,
+                    y.MaxIOPS as maxIOPS,
+                    y.MaxSizeInGib as maxSizeInGib,
+                    y.MaxThroughputInMbps as maxThroughputInMbps,
+                    y.Redundancy as redundancy,
+                    y.Size as size,
+                    y.Type as type
+                  )
+                ) as tempDbDiskSizes,
+                x.targetSku.virtualMachineSize as virtualMachineSize
+              ) as targetSku,
+              x.monthlyCost as monthlyCost
+            )
+          )
+          """
+        )
+    )
 
     jsonResultDf.printSchema()
     jsonResultDf.show(false)

--- a/pricing-poc/src/main/scala/example/reader/JsonReader.scala
+++ b/pricing-poc/src/main/scala/example/reader/JsonReader.scala
@@ -14,4 +14,16 @@ object JsonReader {
   ) = {
     spark.read.option("multiline", "true").schema(schema).json(filePath)
   }
+
+  def readJsonWithSchemaInferred(
+      spark: SparkSession,
+      payloadFilePath: String,
+      schemaSampleFilePath: String
+  ): DataFrame = spark.read.option("multiline", "true")
+                      .schema(
+                        spark.read.option("multiline", "true")
+                             .json(schemaSampleFilePath)
+                             .schema
+                       )
+                      .json(payloadFilePath)
 }


### PR DESCRIPTION
Reduces the log verbosity for Spark.

To solve the null SKU VM problem, we take in a full fledged schema to cast the `DataFrame`.

And the transformation now does this:

```json
{
    "skuRecommendationResults": [
        {
            "recommendationStatus": "NotReady",
            "numberOfServerBlockerIssues": 0,
            "targetSku": {
                "category": {
                    "computeTier": "Provisioned",
                    "hardwareType": "Gen5",
                    "sqlPurchasingModel": "vCore",
                    "sqlServiceTier": "General Purpose",
                    "zoneRedundancyAvailable": false
                },
                "storageMaxSizeInMb": 1024.0,
                "predictedDataSizeInMb": 21.94,
                "predictedLogSizeInMb": 2.0,
                "maxStorageIops": 0.06,
                "maxThroughputMBps": 0.0,
                "computeSize": 2
            },
            "monthlyCost": {
                "computeCost": 245.13,
                "storageCost": 0.18,
                "iopsCost": 0.0,
                "totalCost": 245.31
            }
        },
        {
            "recommendationStatus": "Ready",
            "numberOfServerBlockerIssues": 0,
            "targetSku": {
                "category": {
                    "computeTier": "Provisioned",
                    "hardwareType": "Gen5",
                    "sqlPurchasingModel": "vCore",
                    "sqlServiceTier": "Next-Gen General Purpose",
                    "zoneRedundancyAvailable": false
                },
                "storageMaxSizeInMb": 32768.0,
                "predictedDataSizeInMb": 21.94,
                "predictedLogSizeInMb": 2.0,
                "maxStorageIops": 0.06,
                "maxThroughputMBps": 145.0,
                "computeSize": 4
            },
            "monthlyCost": {
                "computeCost": 490.26,
                "storageCost": 0.0,
                "iopsCost": 0.0,
                "totalCost": 490.26
            }
        },
        {
            "recommendationStatus": "Ready",
            "numberOfServerBlockerIssues": 0,
            "targetSku": {
                "category": {
                    "availableVmSkus": [
                        "Standard_D16as_v4",
                        "Standard_D2as_v4",
                        "Standard_D32as_v4",
                        "Standard_D48as_v4",
                        "Standard_D4as_v4",
                        "Standard_D64as_v4",
                        "Standard_D8as_v4",
                        "Standard_D96as_v4"
                    ],
                    "virtualMachineFamily": "standardDASv4Family"
                },
                "predictedDataSizeInMb": 21.94,
                "predictedLogSizeInMb": 2.0,
                "computeSize": 2,
                "dataDiskSizes": [
                    {
                        "caching": "ReadOnly",
                        "maxIOPS": 120.0,
                        "maxSizeInGib": 8.0,
                        "maxThroughputInMbps": 25.0,
                        "redundancy": "LocallyRedundant",
                        "size": "P2",
                        "type": "PremiumSSD"
                    }
                ],
                "logDiskSizes": [
                    {
                        "caching": "None",
                        "maxIOPS": 120.0,
                        "maxSizeInGib": 8.0,
                        "maxThroughputInMbps": 25.0,
                        "redundancy": "LocallyRedundant",
                        "size": "P2",
                        "type": "PremiumSSD"
                    }
                ],
                "tempDbDiskSizes": [],
                "virtualMachineSize": {
                    "azureSkuName": "Standard_D2as_v4",
                    "computeSize": 2,
                    "maxNetworkInterfaces": 0,
                    "sizeName": "D2as_v4",
                    "virtualMachineFamily": "standardDASv4Family",
                    "vCPUsAvailable": 2
                }
            },
            "monthlyCost": {
                "computeCost": 81.98,
                "storageCost": 2.4,
                "iopsCost": 0.0,
                "totalCost": 84.38
            }
        }
    ]
}
```